### PR TITLE
libtool: add support to automate application of FIX-ITs

### DIFF
--- a/Sources/libtool/CMakeLists.txt
+++ b/Sources/libtool/CMakeLists.txt
@@ -4,4 +4,5 @@ target_include_directories(libtool PRIVATE
   ${LLVM_INCLUDE_DIRS}
   ${CLANG_INCLUDE_DIRS})
 target_link_libraries(libtool PRIVATE
+  clangRewriteFrontend
   clangTooling)


### PR DESCRIPTION
Introduce the new `-apply-fixits` and `-inplace` options which allow for
in situ updates to the library.