### PR TITLE
libtool: ignore friend declarations

### DIFF
--- a/Sources/libtool/libtool.cc
+++ b/Sources/libtool/libtool.cc
@@ -95,6 +95,10 @@ public:
     if (llvm::isa<clang::CXXMethodDecl>(FD))
       return true;
 
+    // Ignore friend declarations.
+    if (llvm::isa<clang::FriendDecl>(FD))
+      return true;
+
     // If the function has a dll-interface, it is properly annotated.
     if (FD->hasAttr<clang::DLLExportAttr>() ||
         FD->hasAttr<clang::DLLImportAttr>())
@@ -122,6 +126,10 @@ public:
 
     // If the method has a body, it can be materialized by the user.
     if (MD->hasBody())
+      return true;
+
+    // Ignore friend declarations.
+    if (llvm::isa<clang::FriendDecl>(MD))
       return true;
 
     // Ignore deleted and defaulted members.


### PR DESCRIPTION
Friend declarations may declare functions or types which have
de-restricted access to the type.  Such declarations should not be
treated as declarations to decorate (though this will need to change
eventually as the declarations may serve as forward declarations, and
will require to match the actual declaration or definition if it
follows).