### PR TITLE
libtool: ignore `defaulted` and `deleted` functions

### DIFF
--- a/Sources/libtool/libtool.cc
+++ b/Sources/libtool/libtool.cc
@@ -99,6 +99,10 @@ public:
     if (llvm::isa<clang::FriendDecl>(FD))
       return true;
 
+    // Ignore deleted and defaulted functions (e.g. operators).
+    if (FD->isDeleted() || FD->isDefaulted())
+      return true;
+
     // If the function has a dll-interface, it is properly annotated.
     if (FD->hasAttr<clang::DLLExportAttr>() ||
         FD->hasAttr<clang::DLLImportAttr>())


### PR DESCRIPTION
defaulted and deleted functions may appear in global scope as
freestanding functions.  This may be used to prevent the synthesis of a
freestanding operator overload (e.g.

~~~
Value &operator=(Value &, Value&) = delete;
~~~

These should not be decorated.