### PR TITLE
Create build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # TODO(compnerd) convert this to a build matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - run: |
+        mkdir -p ${{ github.workspace }}/third_party
+        curl -sL https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz -o ${{ github.workspace }}/third_party/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
+        tar Jxf ${{ github.workspace }}/third_party/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz -C ${{ github.workspace }}/third_party --strip-components 1
+
+    - name: Configure CMake
+      run: cmake -B ${{ github.workspace }}/build -D CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -D LLVM_DIR=${{ github.workspace }}/third_party/lib/cmake/llvm -D Clang_DIR=${{ github.workspace }}/third_party/lib/cmake/clang
+
+    - name: Build
+      run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
+
+    # - name: Test
+    #   working-directory: ${{github.workspace}}/build
+    #   run: ctest -C ${{ env.BUILD_TYPE }}
+      


### PR DESCRIPTION
Setup CI to validate building pre-commit.  This currently builds only on Ubuntu as the prebuilt-release for Ubuntu makes it easy to setup.  This would ideally be setup across all platforms as the tooling itself should be able to run on all platforms.