### PR TITLE
libtool: add a `contains` helper for `std::set`

### DIFF
--- a/Sources/libtool/libtool.cc
+++ b/Sources/libtool/libtool.cc
@@ -85,10 +85,6 @@ public:
   explicit visitor(clang::ASTContext &context)
       : context_(context), source_manager_(context.getSourceManager()) {}
 
-  bool VisitVarDecl(clang::VarDecl *VD) {
-    return true;
-  }
-
   bool VisitFunctionDecl(clang::FunctionDecl *FD) {
     clang::FullSourceLoc location = get_location(FD);
 


### PR DESCRIPTION
Inspired by `std::set::contains` in c++20, this adds a freestanding
equivalent for the contains method to make the path easier to follow.