### PR TITLE
libtool: ignore pure methods

### DIFF
--- a/Sources/libtool/libtool.cc
+++ b/Sources/libtool/libtool.cc
@@ -117,6 +117,10 @@ public:
           exported_private_interface(location) << MD;
         return true;
       }
+
+      // Pure virtual methods cannot be exported.
+      if (MD->isPure())
+        return true;
     }
 
     // If the function has a dll-interface, it is properly annotated.


### PR DESCRIPTION
pure methods do not need to be exported as they indicate a requirement rather
than an implementation.