### PR TITLE
CI: add support to build FileCheck from LLVM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,25 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: llvm/llvm-project
+        ref: llvmorg-12.0.1
+        path: llvm-project
+        fetch-depth: 1
+    - id: llvm-revision
+      run: |
+        echo "::set-output name=revision::$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)"
+    - uses: actions/cache@v2
+      id: llvm-build
+      with:
+        path: ${{ github.workspace }}/build/llvm-project
+        key: ${{ runner.os }}-${{ steps.llvm-revision.outputs.revision }}
+    - if: steps.llvm-build.outputs.cache-hit != 'true'
+      run: |
+        cmake -B ${{ github.workspace }}/build/llvm-project -D CMAKE_BUILD_TYPE=Release -S ${{ github.workspace }}/llvm-project/llvm
+        cmake --build ${{ github.workspace }}/build/llvm-project --config Release --target FileCheck
+
+    - uses: actions/checkout@v2
 
     - run: |
         mkdir -p ${{ github.workspace }}/third_party


### PR DESCRIPTION
This is meant to help add testing, which will rely on lit and FileCheck.