### PR TITLE
idt: remove stale workaround

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -1,9 +1,6 @@
 // Copyright (c) 2021 Saleem Abdulrasool.  All Rights Reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-// NOTE(compnerd) workaround LLVM 16 not including necessary headers.
-#include <optional>
-
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Frontend/CompilerInstance.h"


### PR DESCRIPTION
Since we are now building against LLVM 17, the workaround for LLVM 16 appears to no longer be required.