### PR TITLE
Allow optionally building as a sub project of LLVM using LLVM_EXTERNAL_PROJECTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # Allow adding this project as a external project to the LLVM build system using LLVM_EXTERNAL_PROJECTS
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   find_package(LLVM REQUIRED)
   message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
   message(STATUS "Using LLVMConfig.cmake in ${LLVM_DIR}")
@@ -25,12 +25,10 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 else()
   set(CLANG_INCLUDE_DIRS
     "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include"
-    "${CMAKE_BINARY_DIR}/tools/clang/include"
-  )
+    "${CMAKE_BINARY_DIR}/tools/clang/include")
   set(LLVM_INCLUDE_DIRS
     "${CMAKE_SOURCE_DIR}/include"
-    "${CMAKE_BINARY_DIR}/include"
-  )
+    "${CMAKE_BINARY_DIR}/include")
 endif()
 
 add_subdirectory(Sources)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,25 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-find_package(LLVM REQUIRED)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in ${LLVM_DIR}")
+# Allow adding this project as a external project to the LLVM build system using LLVM_EXTERNAL_PROJECTS
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  find_package(LLVM REQUIRED)
+  message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+  message(STATUS "Using LLVMConfig.cmake in ${LLVM_DIR}")
 
-find_package(Clang REQUIRED)
-message(STATUS "Found Clang ${Clang_PACKAGE_VERSION}")
-message(STATUS "Using ClangConfig.cmake in ${Clang_DIR}")
+  find_package(Clang REQUIRED)
+  message(STATUS "Found Clang ${Clang_PACKAGE_VERSION}")
+  message(STATUS "Using ClangConfig.cmake in ${Clang_DIR}")
+else()
+  set(CLANG_INCLUDE_DIRS
+    "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include"
+    "${CMAKE_BINARY_DIR}/tools/clang/include"
+  )
+  set(LLVM_INCLUDE_DIRS
+    "${CMAKE_SOURCE_DIR}/include"
+    "${CMAKE_BINARY_DIR}/include"
+  )
+endif()
 
 add_subdirectory(Sources)
 add_subdirectory(Tests)


### PR DESCRIPTION
This greatly improves the editing and debugging experience in visual studio when navigating to Clang code from the idt code.

Two CMake variables need to set for the LLVM project to use this 
LLVM_EXTERNAL_PROJECTS="IDS"
LLVM_EXTERNAL_IDS_SOURCE_DIR="SomeDirectory/InterfaceDefinitionScanner"