### PR TITLE
add a test case that uses compilation database

### DIFF
--- a/Tests/GlobalIncludes.cc
+++ b/Tests/GlobalIncludes.cc
@@ -1,0 +1,10 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: echo "[{\"directory\":\"%p\",\"command\":\"clang++ -c GlobalIncludes.cc -I%p/include\",\"file\":\"%t/GlobalIncludes.obj\"}]" | sed -e 's/\\/\\\\/g' > %t/compile_commands.json
+// RUN: %idt -p %t -export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+#include <GlobalHeader.h>
+// CHECK: [[PATH:(.*[\\\/])?include[\\\/]GlobalHeader\.h]]:1:1: remark: unexported public interface 'globalFunction'
+
+static void testFunction() {
+  globalFunction();
+}

--- a/Tests/include/GlobalHeader.h
+++ b/Tests/include/GlobalHeader.h
@@ -1,0 +1,1 @@
+void globalFunction();

--- a/Tests/lit.cfg
+++ b/Tests/lit.cfg
@@ -39,7 +39,7 @@ if not use_lit_shell:
 
 config.test_format = lit.formats.ShTest(execute_external = False)
 
-config.suffixes = ['.hh']
+config.suffixes = ['.hh', '.cc']
 config.excludes = ['CMakeLists.txt']
 
 config.test_source_root = os.path.join(ids_src_root, 'Tests')


### PR DESCRIPTION
## Purpose
Add a lit-based test case for `idt` that verifies it properly uses a clang compilation database when provided via the `-p` command line argument.

## Overview
* Add a new test source file `GlobalIncludes.cc` that depends on header file `GlobalHeader.h` which is located in a new `iuncludes` sub-directory and defines a public function `globalFunction`
* Generate a `compile_commands.json` file as part of testing `GlobalIncludes.cc` which adds the new `includes` subdir to the include path during compilation
* Verify `idt` generates a warning that `globalFunction`, defined in the included header`, is not annotated as an exported fucntion
* Update lit config to include .cc files when testing

## Validation
* Locally verified the test passes on Windows 11
* Verified the new test [runs and passes on Linux in CI](https://github.com/andrurogerz/ids/actions/runs/13126131793)