### PR TITLE
replace static ID fields with std::optional

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <set>
 #include <string>
+#include <optional>
 
 namespace idt {
 llvm::cl::OptionCategory category{"interface definition scanner options"};
@@ -69,27 +70,31 @@ namespace idt {
 class visitor : public clang::RecursiveASTVisitor<visitor> {
   clang::ASTContext &context_;
   clang::SourceManager &source_manager_;
+  std::optional<unsigned> id_unexported_;
+  std::optional<unsigned> id_exported_;
 
   clang::DiagnosticBuilder
   unexported_public_interface(clang::SourceLocation location) {
     clang::DiagnosticsEngine &diagnostics_engine = context_.getDiagnostics();
 
-    static unsigned kID =
-        diagnostics_engine.getCustomDiagID(clang::DiagnosticsEngine::Remark,
-                                           "unexported public interface %0");
+    if (!id_unexported_)
+      id_unexported_ =
+          diagnostics_engine.getCustomDiagID(clang::DiagnosticsEngine::Remark,
+                                             "unexported public interface %0");
 
-    return diagnostics_engine.Report(location, kID);
+    return diagnostics_engine.Report(location, *id_unexported_);
   }
 
   clang::DiagnosticBuilder
   exported_private_interface(clang::SourceLocation location) {
     clang::DiagnosticsEngine &diagnostics_engine = context_.getDiagnostics();
 
-    static unsigned kID =
-        diagnostics_engine.getCustomDiagID(clang::DiagnosticsEngine::Remark,
-                                           "exported private interface %0");
+    if (!id_exported_)
+      id_exported_ =
+          diagnostics_engine.getCustomDiagID(clang::DiagnosticsEngine::Remark,
+                                             "exported private interface %0");
 
-    return diagnostics_engine.Report(location, kID);
+    return diagnostics_engine.Report(location, *id_exported_);
   }
 
   template <typename Decl_>

--- a/Tests/MultipleFiles.hh
+++ b/Tests/MultipleFiles.hh
@@ -1,0 +1,11 @@
+// RUN: %idt -export-macro IDT_TEST_ABI %S/Variables.hh %S/TemplateFunctions.hh 2>&1 | %FileCheck %s
+
+// CHECK: Variables.hh:8:3: remark: unexported public interface 'public_static_class_field'
+// CHECK: Variables.hh:11:3: remark: unexported public interface 'public_static_const_class_field'
+// CHECK: Variables.hh:29:3: remark: unexported public interface 'public_static_struct_field'
+// CHECK: Variables.hh:32:3: remark: unexported public interface 'public_static_const_struct_field'
+// CHECK: Variables.hh:46:1: remark: unexported public interface 'extern_variable'
+// CHECK: Variables.hh:49:1: remark: unexported public interface 'extern_const_variable'
+// CHECK: Variables.hh:52:1: remark: unexported public interface 'ignored_extern_variable'
+// CHECK: Variables.hh:59:3: remark: unexported public interface 'extern_local_variable'
+// CHECK: TemplateFunctions.hh:10:1: remark: unexported public interface 'template_function_inline<char>'


### PR DESCRIPTION
Clang diagnostic IDs are per-translation unit. Replace `static` field memoization in the AST visitor with per-instance `std::optional` memoization to ensures diagnostic IDs are not reused across files.

## Validation
Add a new test case that runs idt against two existing test files rather than itself.

