### PR TITLE
do not add export annotation to friend function declarations

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -135,7 +135,7 @@ public:
       return true;
 
     // Ignore friend declarations.
-    if (llvm::isa<clang::FriendDecl>(FD))
+    if (FD->getFriendObjectKind() != clang::Decl::FOK_None)
       return true;
 
     // Ignore deleted and defaulted functions (e.g. operators).

--- a/Tests/FriendDecls.hh
+++ b/Tests/FriendDecls.hh
@@ -1,8 +1,14 @@
 // RUN: %idt -export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
 
-// XFAIL: *
+void declared_friend_function();
 
 struct record {
   friend void friend_function();
-// CHECK-NOT: FriendDecls.hh:[[@LINE-1]]:3: remark: unexported public interface 'friend_function'
+// CHECK-NOT: FriendDecls.hh:[[@LINE-1]]:{{.*}}
+
+  friend void declared_friend_function();
+// CHECK-NOT: FriendDecls.hh:[[@LINE-1]]:{{.*}}
+
+  void non_friend_function();
+// CHECK: FriendDecls.hh:[[@LINE-1]]:3: remark: unexported public interface 'non_friend_function'
 };


### PR DESCRIPTION
ids was not properly detecting `friend` function declarations so they were being annotated like any other function declaration. There are instances where this is actually correct (they need to match the actual function declaration), but the tool does not have enough information to make that decision so it is safer to annotate friend function declarations.

The `getFriendObjectKind` method is documented [here](https://clang.llvm.org/doxygen/DeclBase_8h_source.html#l01215)

### Validation
Re-enabled the `friend` test case that was previously marked `XFAIL`.
Enhance the `friend` test case to cover the three return values from `getFriendObjectKind`.