### PR TITLE
do not annotate function decls outside of header files

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -126,6 +126,10 @@ public:
     if (source_manager_.isInSystemHeader(location))
       return true;
 
+    // Skip declarations not in header files.
+    if (!is_in_header(FD))
+      return true;
+
     // We are only interested in non-dependent types.
     if (FD->isDependentContext())
       return true;

--- a/Tests/SourceFile.cc
+++ b/Tests/SourceFile.cc
@@ -1,0 +1,4 @@
+// RUN: %idt -export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+void testFunctionDecl();
+// CHECK-NOT: SourceFile.cc:[[@LINE-1]]:{{.*}}


### PR DESCRIPTION
We should generally only be annotated methods and functions declared in header files not in source files. This matches the behavior for extern variable declarations that was added in #36.

## Validation
Added a new test case that fails without the new `is_header_check`.