### PR TITLE
support optionally emitting a fix to include a required header file

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -4,15 +4,20 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Lex/PPCallbacks.h"
+#include "clang/Lex/Preprocessor.h"
 #include "clang/Rewrite/Frontend/FixItRewriter.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
 
 #include <cstdlib>
 #include <iostream>
+#include <optional>
 #include <set>
 #include <string>
-#include <optional>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
 
 namespace idt {
 llvm::cl::OptionCategory category{"interface definition scanner options"};
@@ -33,6 +38,10 @@ export_macro("export-macro",
              llvm::cl::desc("The macro to decorate interfaces with"),
              llvm::cl::value_desc("define"), llvm::cl::Required,
              llvm::cl::cat(idt::category));
+
+llvm::cl::opt<std::string> include_header(
+    "include-header", llvm::cl::desc("Header required for export macro"),
+    llvm::cl::value_desc("header"), llvm::cl::cat(idt::category));
 
 llvm::cl::opt<bool>
 apply_fixits("apply-fixits", llvm::cl::init(false),
@@ -67,14 +76,100 @@ const std::set<std::string> &get_ignored_symbols() {
 }
 
 namespace idt {
+struct IncludeCollector : clang::PPCallbacks {
+  using IncludeInfo = std::tuple<std::string, clang::SourceLocation>;
+  using IncludesMap = std::unordered_map<std::string, std::vector<IncludeInfo>>;
+
+  explicit IncludeCollector(clang::SourceManager &source_manager,
+                            IncludesMap &includes_map)
+      : source_manager_(source_manager), includes_map_(includes_map) {}
+
+  void
+  InclusionDirective(clang::SourceLocation HashLoc,
+                     const clang::Token &IncludeTok, clang::StringRef FileName,
+                     bool IsAngled, clang::CharSourceRange FilenameRange,
+                     clang::OptionalFileEntryRef File,
+                     clang::StringRef SearchPath, clang::StringRef RelativePath,
+                     const clang::Module *SuggestedModule, bool ModuleImported,
+                     clang::SrcMgr::CharacteristicKind FileType) override {
+
+    // Track the name and location of each include in the order discovered.
+    clang::SourceLocation sourceLoc = source_manager_.getSpellingLoc(HashLoc);
+    std::string containingFileName =
+        source_manager_.getFilename(sourceLoc).str();
+
+    // Only add the include to the list if it isn't already present.
+    auto &includesList = includes_map_[containingFileName];
+    auto found = std::find_if(includesList.begin(), includesList.end(),
+                              [&FileName](const IncludeInfo &include) {
+                                return std::get<0>(include) == FileName.str();
+                              });
+    if (found == includesList.end())
+      includesList.emplace_back(FileName.str(), sourceLoc);
+  }
+
+private:
+  clang::SourceManager &source_manager_;
+  IncludesMap &includes_map_;
+};
+
 class visitor : public clang::RecursiveASTVisitor<visitor> {
   clang::ASTContext &context_;
   clang::SourceManager &source_manager_;
   std::optional<unsigned> id_unexported_;
   std::optional<unsigned> id_exported_;
+  IncludeCollector::IncludesMap &includes_map_;
+
+  void add_missing_include(clang::SourceLocation location) {
+    if (include_header.empty())
+      return;
+
+    clang::DiagnosticsEngine &diagnostics_engine = context_.getDiagnostics();
+
+    static unsigned kID = diagnostics_engine.getCustomDiagID(
+        clang::DiagnosticsEngine::Remark, "missing include statement %0");
+
+    clang::SourceLocation spellingLoc =
+        source_manager_.getSpellingLoc(location);
+    const std::string fileName = source_manager_.getFilename(spellingLoc).str();
+    auto &includesList = includes_map_[fileName];
+
+    // TODO: if the modified file contains no existing include directives, we
+    // cannot currently determine where to insert the required include.
+    if (includesList.empty())
+      return;
+
+    // Determine if the header is already included.
+    auto position =
+        std::find_if(includesList.begin(), includesList.end(),
+                     [](const IncludeCollector::IncludeInfo &include) {
+                       return std::get<0>(include) == include_header;
+                     });
+    if (position != includesList.end())
+      return;
+
+    // Insert the new include at the start of the existing include list. Rely
+    // on clang-format to properly sort the include statements in alphabetical
+    // order.
+    clang::SourceLocation insertLoc =
+        source_manager_.getSpellingLoc(std::get<1>(includesList.front()));
+
+    // Emit the fix-it hint to add the include statement.
+    std::string FixText = "#include \"" + include_header + "\"\n";
+    clang::FixItHint FixIt =
+        clang::FixItHint::CreateInsertion(insertLoc, FixText);
+    diagnostics_engine.Report(insertLoc, kID) << include_header << FixIt;
+
+    // Add the new include to our list so we don't add it again.
+    includesList.insert(
+        includesList.begin(),
+        std::tuple(static_cast<std::string>(include_header), insertLoc));
+  }
 
   clang::DiagnosticBuilder
   unexported_public_interface(clang::SourceLocation location) {
+    add_missing_include(location);
+
     clang::DiagnosticsEngine &diagnostics_engine = context_.getDiagnostics();
 
     if (!id_unexported_)
@@ -105,19 +200,21 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
   template <typename Decl_>
   bool is_in_header(const Decl_ *D) const {
     const clang::FullSourceLoc location = get_location(D);
-  const clang::FileID id = source_manager_.getFileID(location);
-  if (const auto entry = source_manager_.getFileEntryRefForID(id)) {
-    const llvm::StringRef name = entry->getName();
-    for (const auto &extension : { ".h", ".hh", ".hpp", ".hxx" })
-      if (name.ends_with(extension))
-        return true;
+    const clang::FileID id = source_manager_.getFileID(location);
+    if (const auto entry = source_manager_.getFileEntryRefForID(id)) {
+      const llvm::StringRef name = entry->getName();
+      for (const auto &extension : {".h", ".hh", ".hpp", ".hxx"})
+        if (name.ends_with(extension))
+          return true;
     }
     return false;
   }
 
 public:
-  explicit visitor(clang::ASTContext &context)
-      : context_(context), source_manager_(context.getSourceManager()) {}
+  explicit visitor(clang::ASTContext &context,
+                   IncludeCollector::IncludesMap &includes_map)
+      : context_(context), source_manager_(context.getSourceManager()),
+        includes_map_(includes_map) {}
 
   bool VisitFunctionDecl(clang::FunctionDecl *FD) {
     clang::FullSourceLoc location = get_location(FD);
@@ -241,8 +338,9 @@ class consumer : public clang::ASTConsumer {
   std::unique_ptr<clang::FixItRewriter> rewriter_;
 
 public:
-  explicit consumer(clang::ASTContext &context)
-      : visitor_(context) {}
+  explicit consumer(clang::ASTContext &context,
+                    IncludeCollector::IncludesMap &includes_map)
+      : visitor_(context, includes_map) {}
 
   void HandleTranslationUnit(clang::ASTContext &context) override {
     if (apply_fixits) {
@@ -263,10 +361,31 @@ public:
 };
 
 struct action : clang::ASTFrontendAction {
+  void ExecuteAction() override {
+    if (!include_header.empty())
+      installIncludeCollector();
+
+    clang::ASTFrontendAction::ExecuteAction();
+  }
+
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &CI, llvm::StringRef) override {
-    return std::make_unique<idt::consumer>(CI.getASTContext());
+    return std::make_unique<idt::consumer>(CI.getASTContext(), includes_map_);
   }
+
+private:
+  // Install a callback that will be invoked on every preprocessor include
+  // statement. This is done so we can determine if a user-specified custom
+  // include statment needs to be added if any annotations are added.
+  void installIncludeCollector() {
+    clang::CompilerInstance &compiler_instance = getCompilerInstance();
+    clang::Preprocessor &preprocessor = compiler_instance.getPreprocessor();
+    clang::SourceManager &source_manager = compiler_instance.getSourceManager();
+    preprocessor.addPPCallbacks(
+        std::make_unique<IncludeCollector>(source_manager, includes_map_));
+  }
+
+  IncludeCollector::IncludesMap includes_map_;
 };
 
 struct factory : clang::tooling::FrontendActionFactory {

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -166,6 +166,7 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
         source_manager_.getSpellingLoc(std::get<1>(includes.front()));
 
     // Emit the fix-it hint to add the include statement.
+    // TODO: consider using std::format after moving to C++20
     std::string FixText = "#include \"" + include_header + "\"\n";
     clang::FixItHint FixIt =
         clang::FixItHint::CreateInsertion(insertLoc, FixText);

--- a/Tests/MissingInclude.hh
+++ b/Tests/MissingInclude.hh
@@ -1,0 +1,20 @@
+// RUN: %idt --include-header="project/ExportDefs.h" -export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s --check-prefix=CHECK-ADD-INCLUDE
+// RUN: %idt -export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s --check-prefix=CHECK-NO-INCLUDE
+
+#pragma once
+
+#include "MissingInclude.hh"
+// CHECK-ADD-INCLUDE: MissingInclude.hh:[[@LINE-1]]:1: remark: missing include statement project/ExportDefs.h
+// CHECK-ADD-INCLUDE-NOT: MissingInclude.hh:[[@LINE-2]]:1: remark: missing include statement project/ExportDefs.h
+// CHECK-NO-INCLUDE-NOT: MissingInclude.hh:[[@LINE-3]]:1: remark: missing include statement project/ExportDefs.h
+
+// Each of the following declarations should get annotated by IDS, but the new
+// #include statement should only get added once.
+
+void function();
+// CHECK-ADD-INCLUDE: MissingInclude.hh:[[@LINE-1]]:1: remark: unexported public interface 'function'
+// CHECK-NO-INCLUDE: MissingInclude.hh:[[@LINE-2]]:1: remark: unexported public interface 'function'
+
+extern int variable;
+// CHECK-ADD-INCLUDE: MissingInclude.hh:[[@LINE-1]]:1: remark: unexported public interface 'variable'
+// CHECK-NO-INCLUDE: MissingInclude.hh:[[@LINE-2]]:1: remark: unexported public interface 'variable'


### PR DESCRIPTION
Add optional IDS support to add a new `#include` directive to scanned/patched files.

## Details
* Introduces a new optional `--include-header` command line argument to IDS. The argument accepts a string value, which will be used to generate an `#include "<value>"` fix-it for any files requiring modification that don't already include the header.
* Defines a new `clang::PPCallbacks` derived class, `IncludeCollector `, which creates a map of filename to its list of include directives.
* Whenever an unexported public interface is detected, a fix-it to add an `#include` statement for the missing header is generated. The statement is added at the start of the first block of include statements already in the file.

## Limitations
* It does not insert the include statement in alphabetical order. The tool already relies on clang-format to fix any formatting issues introduced when adding annotations, and clang-format already re-orders include statements to maintain alphabetical order.
* If the file does not have any existing include statements, it skips adding the new one. It is an uncommon case and wasn't worth the additional trouble to try to locate the best place to add the statement.

## Validation
* New test cases.
* I have been running this change locally to codemod LLVM source and it is working as expected.