### PR TITLE
[ids] support default visibility attributes in addition to dllimport/dllexport

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -233,7 +233,7 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
     // Check if the symbol is annotated with [[gnu::visibility("default")]]
     // or the equivalent __attribute__((visibility("default")))
     if (const auto *VA = D->template getAttr<clang::VisibilityAttr>())
-      return VA->getVisibility() == clang::VisibilityAttr::Vsibility::Default;
+      return VA->getVisibility() == clang::VisibilityAttr::VsibilityType::Default;
     return false;
   }
 

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -230,14 +230,11 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
         D->template hasAttr<clang::DLLImportAttr>())
       return true;
 
-    const auto visibilityAttr = D->template getAttr<clang::VisibilityAttr>();
-    if (!visibilityAttr)
-      return false;
-
     // Check if the symbol is annotated with [[gnu::visibility("default")]]
     // or the equivalent __attribute__((visibility("default")))
-    return visibilityAttr->getVisibility() ==
-      clang::VisibilityAttr::VisibilityType::Default;
+    const auto visibilityAttr = D->template getAttr<clang::VisibilityAttr>();
+    return visibilityAttr && (visibilityAttr->getVisibility() ==
+      clang::VisibilityAttr::VisibilityType::Default);
   }
 
 public:

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -233,7 +233,7 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
     // Check if the symbol is annotated with [[gnu::visibility("default")]]
     // or the equivalent __attribute__((visibility("default")))
     if (const auto *VA = D->template getAttr<clang::VisibilityAttr>())
-      return VA->getVisibility() == clang::VisibilityAttr::VsibilityType::Default;
+      return VA->getVisibility() == clang::VisibilityAttr::VisibilityType::Default;
     return false;
   }
 

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -222,6 +222,24 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
     return false;
   }
 
+  template <typename Decl_>
+  bool is_symbol_exported(const Decl_ *D) const {
+    // Check if the symbol is annotated with __declspec(dllimport) or
+    // __declspec(dllexport).
+    if (D->hasAttr<clang::DLLExportAttr>() ||
+        D->hasAttr<clang::DLLImportAttr>())
+      return true;
+
+    const auto visibilityAttr = D->getAttr<clang::VisibilityAttr>();
+    if (!visibilityAttr)
+      return false;
+
+    // Check if the symbol is annotated with [[gnu::visibility("default")]]
+    // or the equivalent __attribute__((visibility("default")))
+    return visibilityAttr->getVisibility() ==
+      clang::VisibilityAttr::VisibilityType::Default;
+  }
+
 public:
   visitor(clang::ASTContext &context, PPCallbacks::FileIncludes &file_includes)
       : context_(context), source_manager_(context.getSourceManager()),
@@ -257,8 +275,7 @@ public:
     if (const auto *MD = llvm::dyn_cast<clang::CXXMethodDecl>(FD)) {
       // Ignore private members (except for a negative check).
       if (MD->getAccess() == clang::AccessSpecifier::AS_private) {
-        // TODO(compnerd) this should also handle `__visibility__`
-        if (MD->hasAttr<clang::DLLExportAttr>())
+        if (is_symbol_exported(MD))
           // TODO(compnerd) this should emit a fix-it to remove the attribute
           exported_private_interface(location) << MD;
         return true;
@@ -270,9 +287,7 @@ public:
     }
 
     // If the function has a dll-interface, it is properly annotated.
-    // TODO(compnerd) this should also handle `__visibility__`
-    if (FD->hasAttr<clang::DLLExportAttr>() ||
-        FD->hasAttr<clang::DLLImportAttr>())
+    if (is_symbol_exported(FD))
       return true;
 
     // Ignore known forward declarations (builtins)
@@ -297,8 +312,7 @@ public:
   // VisitVarDecl will visit all variable declarations as well as static fields
   // in classes and structs. Non-static fields are not visited by this method.
   bool VisitVarDecl(clang::VarDecl *VD) {
-    if (VD->hasAttr<clang::DLLExportAttr>() ||
-        VD->hasAttr<clang::DLLImportAttr>())
+    if (is_symbol_exported(VD))
       return true;
 
     if (VD->hasInit())

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -226,11 +226,11 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
   bool is_symbol_exported(const Decl_ *D) const {
     // Check if the symbol is annotated with __declspec(dllimport) or
     // __declspec(dllexport).
-    if (D->hasAttr<clang::DLLExportAttr>() ||
-        D->hasAttr<clang::DLLImportAttr>())
+    if (D->template hasAttr<clang::DLLExportAttr>() ||
+        D->template hasAttr<clang::DLLImportAttr>())
       return true;
 
-    const auto visibilityAttr = D->getAttr<clang::VisibilityAttr>();
+    const auto visibilityAttr = D->template getAttr<clang::VisibilityAttr>();
     if (!visibilityAttr)
       return false;
 

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -232,9 +232,9 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
 
     // Check if the symbol is annotated with [[gnu::visibility("default")]]
     // or the equivalent __attribute__((visibility("default")))
-    const auto visibilityAttr = D->template getAttr<clang::VisibilityAttr>();
-    return visibilityAttr && (visibilityAttr->getVisibility() ==
-      clang::VisibilityAttr::VisibilityType::Default);
+    if (const auto *VA = D->template getAttr<clang::VisibilityAttr>())
+      return VA->getVisibility() == clang::VisibilityAttr::Vsibility::Default;
+    return false;
   }
 
 public:

--- a/Tests/Attributes.hh
+++ b/Tests/Attributes.hh
@@ -1,15 +1,23 @@
 // RUN: %idt -export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
 
-__declspec(dllexport) void functionDLLExport();
+#if defined(_WIN32)
+#define EXPORT_ABI __declspec(dllexport)
+#define IMPORT_ABI __declspec(dllimport)
+#else
+#define EXPORT_ABI __attribute__((visibility("default")))
+#define IMPORT_ABI __attribute__((visibility("default")))
+#endif
+
+EXPORT_ABI void functionDLLExport();
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
-__declspec(dllexport) extern unsigned variableDLLExport;
+EXPORT_ABI extern unsigned variableDLLExport;
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
-__declspec(dllimport) void functionDLLImport();
+IMPORT_ABI void functionDLLImport();
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
-__declspec(dllimport) extern unsigned variableDLLImport;
+IMPORT_ABI extern unsigned variableDLLImport;
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
 __attribute__((visibility("default"))) void functionAttributeVisibilityDefault();

--- a/Tests/Attributes.hh
+++ b/Tests/Attributes.hh
@@ -1,0 +1,31 @@
+// RUN: %idt -export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+__declspec(dllexport) void functionDLLExport();
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+__declspec(dllexport) extern unsigned variableDLLExport;
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+__declspec(dllimport) void functionDLLImport();
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+__declspec(dllimport) extern unsigned variableDLLImport;
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+__attribute__((visibility("default"))) void functionAttributeVisibilityDefault();
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+__attribute__((visibility("default"))) extern unsigned variableAttributeVisibilityDefault;
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+__attribute__((visibility("hidden"))) void functionAttributeVisibilityHidden();
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'functionAttributeVisibilityHidden'
+
+[[gnu::visibility("default")]] void functionGnuVisibilityDefault();
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+[[gnu::visibility("default")]] extern unsigned variableGnuVisibilityDefault;
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+[[gnu::visibility("hidden")]] extern unsigned variableGnuVisibilityHidden;
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'variableGnuVisibilityHidden'

--- a/Tests/Attributes.hh
+++ b/Tests/Attributes.hh
@@ -8,26 +8,47 @@
 #define IMPORT_ABI __attribute__((visibility("default")))
 #endif
 
-EXPORT_ABI void functionDLLExport();
+EXPORT_ABI void functionDLLExport1();
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
-EXPORT_ABI extern unsigned variableDLLExport;
+void EXPORT_ABI functionDLLExport2();
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
-IMPORT_ABI void functionDLLImport();
+EXPORT_ABI extern unsigned variableDLLExport1;
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
-IMPORT_ABI extern unsigned variableDLLImport;
+extern EXPORT_ABI unsigned variableDLLExport2;
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
-__attribute__((visibility("default"))) void functionAttributeVisibilityDefault();
+IMPORT_ABI void functionDLLImport1();
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
-__attribute__((visibility("default"))) extern unsigned variableAttributeVisibilityDefault;
+void IMPORT_ABI functionDLLImport2();
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
 
-__attribute__((visibility("hidden"))) void functionAttributeVisibilityHidden();
-// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'functionAttributeVisibilityHidden'
+IMPORT_ABI extern unsigned variableDLLImport1;
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+extern IMPORT_ABI unsigned variableDLLImport2;
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+__attribute__((visibility("default"))) void functionAttributeVisibilityDefault1();
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+void __attribute__((visibility("default"))) functionAttributeVisibilityDefault2();
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+__attribute__((visibility("default"))) extern unsigned variableAttributeVisibilityDefault1;
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+extern __attribute__((visibility("default"))) unsigned variableAttributeVisibilityDefault2;
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+
+__attribute__((visibility("hidden"))) void functionAttributeVisibilityHidden1();
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'functionAttributeVisibilityHidden1'
+
+void __attribute__((visibility("hidden"))) functionAttributeVisibilityHidden2();
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'functionAttributeVisibilityHidden2'
 
 [[gnu::visibility("default")]] void functionGnuVisibilityDefault();
 // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
@@ -37,3 +58,21 @@ __attribute__((visibility("hidden"))) void functionAttributeVisibilityHidden();
 
 [[gnu::visibility("hidden")]] extern unsigned variableGnuVisibilityHidden;
 // CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'variableGnuVisibilityHidden'
+
+[[deprecated]] extern unsigned variableDeprecated;
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'variableDeprecated'
+
+[[deprecated]] void functionDeprecated();
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'functionDeprecated'
+
+__attribute__((unused)) extern unsigned variableUnused1;
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'variableUnused1'
+
+extern __attribute__((unused)) unsigned variableUnused2;
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'variableUnused2'
+
+__attribute__((unused)) void functionUnused1();
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'functionUnused1'
+
+void __attribute__((unused)) functionUnused2();
+// CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'functionUnused2'


### PR DESCRIPTION
Treat visibility default attributes on symbols as exported.
* `[[gnu::visibility("default")]]`
* `__attribute__((visibility("default")))`

###  Validation
Added new tests.
Run tests locally on Windows and Linux.

