### PR TITLE
[ids] do not annotated static fields in un-specialzed template classes/structs

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -321,6 +321,11 @@ public:
         VD->getStorageClass() != clang::StorageClass::SC_Extern)
       return true;
 
+    // Skip static variables in non-specialized template classes and structs.
+    auto *RD = llvm::dyn_cast<clang::CXXRecordDecl>(VD->getDeclContext());
+    if (RD && RD->getDescribedClassTemplate())
+      return true;
+
     // TODO(compnerd) replace with std::set::contains in C++20
     if (contains(get_ignored_symbols(), VD->getNameAsString()))
       return true;

--- a/Tests/Templates.hh
+++ b/Tests/Templates.hh
@@ -1,6 +1,7 @@
 // RUN: %idt --export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
 
-template <typename T>
+// Template struct. No members should be annotated for exort.
+template <typename T1, typename T2>
 struct TemplateStruct {
   static const unsigned const_value;
   // CHECK-NOT: Templates.hh:[[@LINE-1]]:{{.*}}
@@ -12,8 +13,24 @@ struct TemplateStruct {
   // CHECK-NOT: Templates.hh:[[@LINE-1]]:{{.*}}
 };
 
+// Partially-specialized template struct. No members should be annotated for
+// export.
+template <typename T1>
+struct TemplateStruct<T1, unsigned> {
+  static const unsigned const_value;
+  // CHECK-NOT: Templates.hh:[[@LINE-1]]:{{.*}}
+
+  static unsigned value;
+  // CHECK-NOT: Templates.hh:[[@LINE-1]]:{{.*}}
+
+  void method();
+  // CHECK-NOT: Templates.hh:[[@LINE-1]]:{{.*}}
+};
+
+// Fully-specialized template struct. Members should be annotated for export as
+// with any other struct.
 template <>
-struct TemplateStruct<unsigned> {
+struct TemplateStruct<void*, unsigned> {
   static const unsigned const_value;
   // CHECK: Templates.hh:[[@LINE-1]]:3: remark: unexported public interface 'const_value'
 

--- a/Tests/Templates.hh
+++ b/Tests/Templates.hh
@@ -1,0 +1,25 @@
+// RUN: %idt --export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+template <typename T>
+struct TemplateStruct {
+  static const unsigned const_value;
+  // CHECK-NOT: Templates.hh:[[@LINE-1]]:{{.*}}
+
+  static unsigned value;
+  // CHECK-NOT: Templates.hh:[[@LINE-1]]:{{.*}}
+
+  void method();
+  // CHECK-NOT: Templates.hh:[[@LINE-1]]:{{.*}}
+};
+
+template <>
+struct TemplateStruct<unsigned> {
+  static const unsigned const_value;
+  // CHECK: Templates.hh:[[@LINE-1]]:3: remark: unexported public interface 'const_value'
+
+  static unsigned value;
+  // CHECK: Templates.hh:[[@LINE-1]]:3: remark: unexported public interface 'value'
+
+  void method();
+  // CHECK: Templates.hh:[[@LINE-1]]:3: remark: unexported public interface 'method'
+};


### PR DESCRIPTION
## Purpose
No members of un-specialized template classes/structs/unions should be annotated for export.

## Validation
Add new test cases to cover specialized and un-specialized template members.