### PR TITLE
[ids] do not annotate class template argument deductions

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -269,6 +269,10 @@ public:
     if (FD->isDeleted() || FD->isDefaulted())
       return true;
 
+    // Skip template class template argument deductions.
+    if (const auto *DG = llvm::dyn_cast<clang::CXXDeductionGuideDecl>(FD))
+      return true;
+
     if (const auto *MD = llvm::dyn_cast<clang::CXXMethodDecl>(FD)) {
       // Ignore private members (except for a negative check).
       if (MD->getAccess() == clang::AccessSpecifier::AS_private) {

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -270,7 +270,7 @@ public:
       return true;
 
     // Skip template class template argument deductions.
-    if (const auto *DG = llvm::dyn_cast<clang::CXXDeductionGuideDecl>(FD))
+    if (llvm::isa<clang::CXXDeductionGuideDecl>(FD))
       return true;
 
     if (const auto *MD = llvm::dyn_cast<clang::CXXMethodDecl>(FD)) {

--- a/Tests/ClassTemplateArgumentDeduction.hh
+++ b/Tests/ClassTemplateArgumentDeduction.hh
@@ -1,0 +1,7 @@
+// RUN: %idt --export-macro IDT_TEST_ABI --extra-arg="--std=c++17" %s 2>&1 | %FileCheck %s
+
+template <typename T>
+struct TemplateStruct {};
+
+TemplateStruct(unsigned) -> TemplateStruct<unsigned>;
+// CHECK-NOT: ClassTemplateArgumentDeduction.hh:[[@LINE-1]]:{{.*}}


### PR DESCRIPTION
## Purpose
Class template argument deduction (CTAD) statements should not be annotated for export.

## Background
While code-modding llvm with ids, I observed that C++ CTAD statements are visited by `clang::RecursiveASTVisitor::VisitFunctionDecl`. This leads to them being annotated for export, which does not make sense.

## Validation
New test case which fails without the fix.
Ran tests locally on Linux and Windows.