### PR TITLE
[gha] add a Windows build/test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     - id: llvm-revision
       run: echo llvm_revision=$(git -C ${{ github.workspace }}/third_party/llvm-project rev-parse HEAD) >> ${GITHUB_ENV}
 
-    - uses: hendrikmuhs/ccache-action@v1.2.17
+    - uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17 release (2025-02-03)
       with:
         key: ${{ runner.os }}-${{ env.llvm_revision }}
         variant: sccache
@@ -94,7 +94,7 @@ jobs:
         $llvm_revision = git -C ${{ github.workspace }}/third_party/llvm-project rev-parse HEAD
         echo "llvm_revision=$llvm_revision" >> $env:GITHUB_ENV
 
-    - uses: hendrikmuhs/ccache-action@v1.2.17
+    - uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17 release (2025-02-03)
       with:
         key: ${{ runner.os }}-${{ env.llvm_revision }}
         variant: sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
 
     - uses: hendrikmuhs/ccache-action@v1.2.17
       with:
-        max-size: 10M
         key: ${{ runner.os }}-${{ env.llvm_revision }}
         variant: sccache
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,9 @@ jobs:
         fetch-depth: 1
 
     - id: llvm-revision
-      run: echo llvm_revision=$(git -C ${{ github.workspace }}/third_party/llvm-project rev-parse HEAD) >> ${GITHUB_ENV}
+      run: |
+        $llvm_revision = git -C ${{ github.workspace }}/third_party/llvm-project rev-parse HEAD
+        echo "llvm_revision=$llvm_revision" >> $env:GITHUB_ENV
 
     - uses: hendrikmuhs/ccache-action@v1.2.17
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,6 @@ jobs:
         variant: sccache
 
     - name: Setup VSDevEnv
-      if: runner.os == 'Windows'
       uses: compnerd/gha-setup-vsdevenv@v6
       with:
         components: "Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Workload.NativeDesktop"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     - id: llvm-revision
       run: echo llvm_revision=$(git -C ${{ github.workspace }}/third_party/llvm-project rev-parse HEAD) >> ${GITHUB_ENV}
 
-    - uses: hendrikmuhs/ccache-action@4cb35b2ff44ce57e1f5f5221e26bd8fefcfe41d0 # main as of 2024-01-21
+    - uses: hendrikmuhs/ccache-action@v1.2.17
       with:
         max-size: 10M
         key: ${{ runner.os }}-${{ env.llvm_revision }}
@@ -74,4 +74,71 @@ jobs:
     - name: Test
       run: >
         cmake --build ${{github.workspace}}/build                               \
+              --target check-ids
+
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Checkout LLVM
+      uses: actions/checkout@v4
+      with:
+        repository: llvm/llvm-project
+        ref: llvmorg-${{ env.LLVM_VERSION }}
+        path: third_party/llvm-project
+        fetch-depth: 1
+
+    - id: llvm-revision
+      run: echo llvm_revision=$(git -C ${{ github.workspace }}/third_party/llvm-project rev-parse HEAD) >> ${GITHUB_ENV}
+
+    - uses: hendrikmuhs/ccache-action@v1.2.17
+      with:
+        key: ${{ runner.os }}-${{ env.llvm_revision }}
+        variant: sccache
+
+    - name: Setup VSDevEnv
+      if: runner.os == 'Windows'
+      uses: compnerd/gha-setup-vsdevenv@v6
+      with:
+        components: "Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Workload.NativeDesktop"
+
+    - name: Configure LLVM
+      run: |
+        cmake -B ${{ github.workspace }}/build/llvm-project                     `
+              -D LLVM_ENABLE_PROJECTS="lld;clang"                               `
+              -D LLVM_TARGETS_TO_BUILD="host"                                   `
+              -D CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}                         `
+              -D CMAKE_C_COMPILER_LAUNCHER=sccache                              `
+              -D CMAKE_CXX_COMPILER_LAUNCHER=sccache                            `
+              -S ${{ github.workspace }}/third_party/llvm-project/llvm          `
+              -G Ninja
+
+    - name: Build LLVM
+      run: |
+        cmake --build ${{ github.workspace }}/build/llvm-project                `
+              --config ${{ env.BUILD_TYPE }}
+
+    - name: Configure IDS
+      run: |
+        cmake -B ${{ github.workspace }}/build                                                          `
+              -D CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}                                                 `
+              -D CMAKE_C_COMPILER=${{ github.workspace }}/build/llvm-project/bin/clang.exe              `
+              -D CMAKE_CXX_COMPILER=${{ github.workspace }}/build/llvm-project/bin/clang++.exe          `
+              -D LLVM_DIR=${{ github.workspace }}/build/llvm-project/lib/cmake/llvm                     `
+              -D Clang_DIR=${{ github.workspace }}/build/llvm-project/lib/cmake/clang                   `
+              -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/FileCheck          `
+              -D LIT_EXECUTABLE=${{ github.workspace }}/third_party/llvm-project/llvm/utils/lit/lit.py  `
+              -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld                                                    `
+              -G Ninja
+
+    - name: Build IDS
+      run: |
+        cmake --build ${{ github.workspace }}/build                             `
+              --config ${{ env.BUILD_TYPE }}
+
+    - name: Test IDS
+      run: |
+        cmake --build ${{github.workspace}}/build                               `
               --target check-ids

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ env:
   SCCACHE_DIRECT: yes
 
 jobs:
-  build:
+  build-ubuntu:
     # TODO(compnerd) convert this to a build matrix
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Purpose
Add a Windows build & test job to the existing build GitHub Action for IDS.

### Overview
1. Add a Windows job to build LLVM, IDS, and run the IDS tests.
2. Rename the Linux build job to `build-ubuntu` for clarity.
3. Remove the sccache size limit on the build-ubuntu job to resolve I/O failures.
4. Update the `hendrikmuhs/ccache-action` version used by the `build-ubuntu` job. It was failing to save the cache due to some GitHub cache API changes.

NOTE: We do a full build of LLVM for windows, rather than downloading LLVM pre-builts as we do on Linux. This is because there is no pre-built Windows package containing the set of libraries and config files we need to build IDS on Windows. However, because we always build at the same LLVM revision, sccache ensures the build is fast so this won't impact build times significantly. It took <15 min on my fork with 100% sccache hits.

### Validation
Manually triggered two runs on my IDS fork
* https://github.com/andrurogerz/ids/actions/runs/14602272501
* https://github.com/andrurogerz/ids/actions/runs/14606480065

First one was slow due to unpopulated sccache. Second one was 13 min.