### PR TITLE
add class-level annotations for classes with virtual methods

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -252,10 +252,9 @@ public:
     // exported on non-Windows platforms. Do this regardless of the method's
     // access level.
     bool should_export_record = false;
-    for (const auto *MD : CD->methods()) {
+    for (const auto *MD : CD->methods())
       if ((should_export_record = (MD->isVirtual() && !MD->hasBody())))
         break;
-    }
 
     const bool is_exported_record = is_symbol_exported(CD);
     if (!is_exported_record && should_export_record) {

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -242,6 +242,21 @@ public:
       : context_(context), source_manager_(context.getSourceManager()),
         file_includes_(file_includes) {}
 
+  bool TraverseCXXRecordDecl(clang::CXXRecordDecl *CD) {
+    // Skip declarations.
+    if (!CD->isThisDeclarationADefinition())
+      return true;
+
+    // Skip anonymous record.
+    if (CD->isAnonymousStructOrUnion())
+      return true;
+
+    if (!RecursiveASTVisitor::TraverseCXXRecordDecl(CD))
+      return false;
+
+    return true;
+  }
+
   bool VisitFunctionDecl(clang::FunctionDecl *FD) {
     clang::FullSourceLoc location = get_location(FD);
 

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -259,25 +259,14 @@ public:
 
     const bool is_exported_record = is_symbol_exported(CD);
     if (!is_exported_record && should_export_record) {
-      // Insert the annotation immediately following the class/struct/union
-      // keyword.
-      clang::LangOptions lang_opts = CD->getASTContext().getLangOpts();
-      clang::SourceLocation loc = CD->getBeginLoc();
-      while (loc.isValid()) {
-        clang::Token token;
-        if (clang::Lexer::getRawToken(loc, token, source_manager_, lang_opts))
-          break;
-
-        loc = token.getEndLoc();
-        if (token.is(clang::tok::kw_class) || token.is(clang::tok::kw_struct) ||
-            token.is(clang::tok::kw_union))
-          break;
-      }
-
+      // Insert the annotation immediately before the class/struct/union name,
+      // which is the position returned by getLocation.
+      clang::LangOptions LO = CD->getASTContext().getLangOpts();
+      clang::SourceLocation loc = CD->getLocation();
       const clang::SourceLocation location =
           context_.getFullLoc(loc).getExpansionLoc();
       unexported_public_interface(location)
-          << CD << clang::FixItHint::CreateInsertion(loc, " " + export_macro);
+          << CD << clang::FixItHint::CreateInsertion(loc, export_macro + " ");
     }
 
     // Save/restore the current value of in_exported_record_ to support nested

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -381,7 +381,7 @@ public:
       return true;
 
     // Skip all other local and global variables unless they are extern.
-    if (!VD->isStatiRDataMember() &&
+    if (!VD->isStaticDataMember() &&
         VD->getStorageClass() != clang::StorageClass::SC_Extern)
       return true;
 

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -133,6 +133,10 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
   std::optional<unsigned> id_exported_;
   PPCallbacks::FileIncludes &file_includes_;
 
+  // This member is set to true when the containing record being traversed (if
+  // any) is already annotated for export.
+  bool in_exported_record_ = false;
+
   void add_missing_include(clang::SourceLocation location) {
     if (include_header.empty())
       return;
@@ -243,18 +247,50 @@ public:
         file_includes_(file_includes) {}
 
   bool TraverseCXXRecordDecl(clang::CXXRecordDecl *CD) {
-    // Skip declarations.
-    if (!CD->isThisDeclarationADefinition())
-      return true;
+    // If a class declaration contains a virtual method without a body, annotate
+    // the class instead of its individual members. This ensures its vtable is
+    // exported on non-Windows platforms. Do this regardless of the method's
+    // access level.
+    bool should_export_record = false;
+    for (const auto *MD : CD->methods()) {
+      if (should_export_record = (MD->isVirtual() && !MD->hasBody()))
+        break;
+    }
 
-    // Skip anonymous record.
-    if (CD->isAnonymousStructOrUnion())
-      return true;
+    const bool is_exported_record = is_symbol_exported(CD);
+    if (!is_exported_record && should_export_record) {
+      // Insert the annotation immediately following the class/struct/union
+      // keyword.
+      clang::LangOptions lang_opts = CD->getASTContext().getLangOpts();
+      clang::SourceLocation loc = CD->getBeginLoc();
+      while (loc.isValid()) {
+        clang::Token token;
+        if (clang::Lexer::getRawToken(loc, token, source_manager_, lang_opts))
+          break;
 
-    if (!RecursiveASTVisitor::TraverseCXXRecordDecl(CD))
-      return false;
+        loc = token.getEndLoc();
+        if (token.is(clang::tok::kw_class) || token.is(clang::tok::kw_struct) ||
+            token.is(clang::tok::kw_union))
+          break;
+      }
 
-    return true;
+      const clang::SourceLocation location =
+          context_.getFullLoc(loc).getExpansionLoc();
+      unexported_public_interface(location)
+          << CD << clang::FixItHint::CreateInsertion(loc, " " + export_macro);
+    }
+
+    // Save/restore the current value of in_exported_record_ to support nested
+    // record definitions.
+    const bool old_in_exported_record = in_exported_record_;
+    in_exported_record_ = is_exported_record || should_export_record;
+
+    // Traverse the class by invoking the parent's version of this method. This
+    // call is required even if the record is exported because it may contain
+    // nested records.
+    const bool result = RecursiveASTVisitor::TraverseCXXRecordDecl(CD);
+    in_exported_record_ = old_in_exported_record;
+    return result;
   }
 
   bool VisitFunctionDecl(clang::FunctionDecl *FD) {
@@ -306,6 +342,11 @@ public:
     if (is_symbol_exported(FD))
       return true;
 
+    // If the containing record is exported, do not annotate individual members.
+    // TODO: if the symbol is already exported, emit a fix-it to remove it.
+    if (in_exported_record_)
+      return true;
+
     // Ignore known forward declarations (builtins)
     if (contains(kIgnoredBuiltins, FD->getNameAsString()))
       return true;
@@ -329,6 +370,11 @@ public:
   // in classes and structs. Non-static fields are not visited by this method.
   bool VisitVarDecl(clang::VarDecl *VD) {
     if (is_symbol_exported(VD))
+      return true;
+
+    // If the containing record is exported, do not annotate individual members.
+    // TODO: if the symbol is already exported, emit a fix-it to remove it.
+    if (in_exported_record_)
       return true;
 
     if (VD->hasInit())

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -253,7 +253,7 @@ public:
     // access level.
     bool should_export_record = false;
     for (const auto *MD : CD->methods()) {
-      if (should_export_record = (MD->isVirtual() && !MD->hasBody()))
+      if ((should_export_record = (MD->isVirtual() && !MD->hasBody())))
         break;
     }
 

--- a/Tests/Attributes.hh
+++ b/Tests/Attributes.hh
@@ -76,3 +76,35 @@ __attribute__((unused)) void functionUnused1();
 
 void __attribute__((unused)) functionUnused2();
 // CHECK: Attributes.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'functionUnused2'
+
+struct EXPORT_ABI ClassDLLExport {
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+  void method();
+  // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+  static unsigned static_field;
+  // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+};
+
+struct IMPORT_ABI ClassDLLImport {
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+  void method();
+  // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+  static unsigned static_field;
+  // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+};
+
+struct __attribute__((visibility("default"))) ClassVisibilityDefault {
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+  void method();
+  // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+  static unsigned static_field;
+  // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+};
+
+struct [[gnu::visibility("default")]] ClassGnuVisibilityDefault {
+// CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+  void method();
+  // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+  static unsigned static_field;
+  // CHECK-NOT: Attributes.hh:[[@LINE-1]]:{{.*}}
+};

--- a/Tests/VTables.hh
+++ b/Tests/VTables.hh
@@ -1,0 +1,57 @@
+// RUN: %idt --export-macro=IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+struct ClassWithInlineVirtualMethod {
+// CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+  virtual void virtualMedhod() {}
+  // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+  void method();
+  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'method'
+  static unsigned static_field;
+  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'static_field'
+};
+
+struct ClassWithExternVirtualMethod {
+// CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'ClassWithExternVirtualMethod'
+private:
+  virtual void virtualMedhod();
+  // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+  void method();
+  // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+};
+
+struct OuterClass {
+// CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+  void method();
+  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'method'
+  class InnerClassWithExternVirtualMethod {
+  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'InnerClassWithExternVirtualMethod'
+  protected:
+    virtual void virtualMethod();
+    // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+    void method();
+    // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+    static unsigned static_field;
+    // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+  };
+
+  struct InnerClassWithInlineVirtualMethod {
+  // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+    void method();
+    // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'method'
+    virtual void virtualMedhod() {}
+    // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+    struct InnerInnerClassWithExternVirtualMethod {
+    // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'InnerInnerClassWithExternVirtualMethod'
+      virtual void virtualMethod();
+      // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+      void method();
+      // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+    };
+
+    static unsigned static_field;
+    // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'static_field'
+  };
+
+  static unsigned static_field;
+  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'static_field'
+};

--- a/Tests/VTables.hh
+++ b/Tests/VTables.hh
@@ -1,57 +1,91 @@
 // RUN: %idt --export-macro=IDT_TEST_ABI %s 2>&1 | %FileCheck %s
 
+// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
 struct ClassWithInlineVirtualMethod {
-// CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
   virtual void virtualMedhod() {}
-  // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+  // CHECK: VTables.hh:[[@LINE+1]]:3: remark: unexported public interface 'method'
   void method();
-  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'method'
+  // CHECK: VTables.hh:[[@LINE+1]]:3: remark: unexported public interface 'static_field'
   static unsigned static_field;
-  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'static_field'
 };
 
+// CHECK: VTables.hh:[[@LINE+1]]:8: remark: unexported public interface 'ClassWithExternVirtualMethod'
 struct ClassWithExternVirtualMethod {
-// CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'ClassWithExternVirtualMethod'
 private:
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
   virtual void virtualMedhod();
-  // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
   void method();
-  // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
 };
 
+// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
 struct OuterClass {
-// CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+  // CHECK: VTables.hh:[[@LINE+1]]:3: remark: unexported public interface 'method'
   void method();
-  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'method'
+  // CHECK: VTables.hh:[[@LINE+1]]:9: remark: unexported public interface 'InnerClassWithExternVirtualMethod'
   class InnerClassWithExternVirtualMethod {
-  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'InnerClassWithExternVirtualMethod'
   protected:
+    // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
     virtual void virtualMethod();
-    // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+    // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
     void method();
-    // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+    // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
     static unsigned static_field;
-    // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
   };
 
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
   struct InnerClassWithInlineVirtualMethod {
-  // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+    // CHECK: VTables.hh:[[@LINE+1]]:5: remark: unexported public interface 'method'
     void method();
-    // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'method'
+    // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
     virtual void virtualMedhod() {}
-    // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+    // CHECK: VTables.hh:[[@LINE+1]]:12: remark: unexported public interface 'InnerInnerClassWithExternVirtualMethod'
     struct InnerInnerClassWithExternVirtualMethod {
-    // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'InnerInnerClassWithExternVirtualMethod'
+      // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
       virtual void virtualMethod();
-      // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
+      // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
       void method();
-      // CHECK-NOT: VTables.hh:[[@LINE-1]]:{{.*}}
     };
-
+    // CHECK: VTables.hh:[[@LINE+1]]:5: remark: unexported public interface 'static_field'
     static unsigned static_field;
-    // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'static_field'
   };
-
+  // CHECK: VTables.hh:[[@LINE+1]]:3: remark: unexported public interface 'static_field'
   static unsigned static_field;
-  // CHECK: VTables.hh:[[@LINE-1]]:{{.*}}: remark: unexported public interface 'static_field'
+};
+
+// CHECK: VTables.hh:[[@LINE+1]]:22: remark: unexported public interface 'NoDiscardAttributeClass'
+struct [[nodiscard]] NoDiscardAttributeClass {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual void method();
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  static unsigned static_field;
+};
+
+// CHECK: VTables.hh:[[@LINE+3]]:1: remark: unexported public interface 'NoDiscardAttributeMultiLineDefClass'
+struct
+[[nodiscard]]
+NoDiscardAttributeMultiLineDefClass {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual void method();
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  static unsigned static_field;
+};
+
+// CHECK: VTables.hh:[[@LINE+1]]:32: remark: unexported public interface 'UnusedAttributeClass'
+struct __attribute__((unused)) UnusedAttributeClass {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual void method();
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  static unsigned static_field;
+};
+
+// CHECK: VTables.hh:[[@LINE+3]]:1: remark: unexported public interface 'UnusedAttributeMultiLineDefClass'
+struct
+__attribute__((unused))
+UnusedAttributeMultiLineDefClass {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual void method();
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  static unsigned static_field;
 };


### PR DESCRIPTION
## Purpose
Enable IDS to annotate more of the LLVM source automatically. Specifically, add the specified export macro at the class level, rather than to individual class members, when the vtable needs to be exported.

## Overview
1. Override `clang::TraverseCXXRecordDecl` in the existing `clang::RecursiveASTVisitor` implementation to check each class for virtual methods without a body.
2. Emit a fix-it to add a class level annotation when a class is found to have a virtual method without a body.
3. Set a member field that is checked by the existing `VisitVarDecl` and `VisitFunctionDecl` methods. These methods skip annotating if the containing class is already annotated.

## Background
Windows does not require class-level export to export vtables, but ELF and Mach-O platforms do. After some experimentation, I determined that the vtable requires export when a class contains at least one virtual method without an inline implementation.

## Validation
Ran all tests on Windows and Linux.
Added new test cases:
1. Test class-level annotations when vtable requires export. Explicitly verify with nested classes.
2. Ensure members are not annotated when the containing class is already annotated.