### PR TITLE
only export specialized template class declarations

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -289,11 +289,24 @@ public:
 
   // RecursiveASTVisitor::TraverseCXXRecordDecl does not get called for fully
   // specialized template declarations. Since we may want to export them,
-  // manually invoke TraverseCXXRecordDecl whenever a specialization
-  // declaration is found.
+  // manually invoke TraverseCXXRecordDecl whenever an explicit specialization
+  // is found.
   bool TraverseClassTemplateSpecializationDecl(
       clang::ClassTemplateSpecializationDecl *SD) {
-    return TraverseCXXRecordDecl(SD);
+    switch (SD->getSpecializationKind()) {
+    case clang::TSK_ExplicitSpecialization:
+      return TraverseCXXRecordDecl(SD);
+
+    // TODO: consider annotation explicit template instantiation declarations
+    // and definitions in the future. They may require unique annotation macros
+    // due to differences between visibility and dllexport/dllimport attributes.
+    case clang::TSK_ExplicitInstantiationDeclaration:
+      [[fallthrough]];
+    case clang::TSK_ExplicitInstantiationDefinition:
+      [[fallthrough]];
+    default:
+      return true;
+    }
   }
 
   bool VisitFunctionDecl(clang::FunctionDecl *FD) {

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -241,12 +241,19 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
     return false;
   }
 
-public:
-  visitor(clang::ASTContext &context, PPCallbacks::FileIncludes &file_includes)
-      : context_(context), source_manager_(context.getSourceManager()),
-        file_includes_(file_includes) {}
+  // Determine if a class/struct/union needs exporting at the record level.
+  // Returns true if the record has been, or was already, annotated. Returns
+  // false otherwise.
+  bool export_record_if_needed(clang::CXXRecordDecl *RD) {
+    // Check if the class is already exported.
+    if (is_symbol_exported(RD))
+      return true;
 
-  bool TraverseCXXRecordDecl(clang::CXXRecordDecl *RD) {
+    // Skip exporting template classes. For fully-specialized template classes,
+    // isTemplated() returns false so they will be annotated if needed.
+    if (RD->isTemplated())
+      return false;
+
     // If a class declaration contains an out-of-line virtual method, annotate
     // the class instead of its individual members. This ensures its vtable is
     // exported on non-Windows platforms. Do this regardless of the method's
@@ -258,26 +265,31 @@ public:
                (MD->isVirtual() && !MD->hasBody())))
         break;
 
-    // Skip exporting template classes. For fully-specialized template classes,
-    // isTemplated() returns false so they will be annotated if needed.
-    should_export_record = should_export_record && !RD->isTemplated();
+    if (!should_export_record)
+      return false;
 
-    const bool is_exported_record = is_symbol_exported(RD);
-    if (!is_exported_record && should_export_record) {
-      // Insert the annotation immediately before the tag name, which is the
-      // position returned by getLocation.
-      clang::LangOptions LO = RD->getASTContext().getLangOpts();
-      clang::SourceLocation SLoc = RD->getLocation();
-      const clang::SourceLocation location =
-          context_.getFullLoc(SLoc).getExpansionLoc();
-      unexported_public_interface(location)
-          << RD << clang::FixItHint::CreateInsertion(SLoc, export_macro + " ");
-    }
+    // Insert the annotation immediately before the tag name, which is the
+    // position returned by getLocation.
+    clang::LangOptions LO = RD->getASTContext().getLangOpts();
+    clang::SourceLocation SLoc = RD->getLocation();
+    const clang::SourceLocation location =
+        context_.getFullLoc(SLoc).getExpansionLoc();
+    unexported_public_interface(location)
+        << RD << clang::FixItHint::CreateInsertion(SLoc, export_macro + " ");
 
+    return true;
+  }
+
+public:
+  visitor(clang::ASTContext &context, PPCallbacks::FileIncludes &file_includes)
+      : context_(context), source_manager_(context.getSourceManager()),
+        file_includes_(file_includes) {}
+
+  bool TraverseCXXRecordDecl(clang::CXXRecordDecl *RD) {
     // Save/restore the current value of in_exported_record_ to support nested
     // record definitions.
     const bool old_in_exported_record = in_exported_record_;
-    in_exported_record_ = is_exported_record || should_export_record;
+    in_exported_record_ = export_record_if_needed(RD);
 
     // Traverse the class by invoking the parent's version of this method. This
     // call is required even if the record is exported because it may contain
@@ -295,6 +307,8 @@ public:
       clang::ClassTemplateSpecializationDecl *SD) {
     switch (SD->getSpecializationKind()) {
     case clang::TSK_ExplicitSpecialization:
+      // This call visits class template specialization record and recursively
+      // visits all of it children, which may also require export.
       return TraverseCXXRecordDecl(SD);
 
     // TODO: consider annotating explicit template instantiation declarations

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -241,7 +241,7 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
     return false;
   }
 
-  // Determine if a class/struct/union needs exporting at the record level.
+  // Determine if a tagged type needs exporting at the record level.
   // Returns true if the record has been, or was already, annotated. Returns
   // false otherwise.
   bool export_record_if_needed(clang::CXXRecordDecl *RD) {

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -297,7 +297,7 @@ public:
     case clang::TSK_ExplicitSpecialization:
       return TraverseCXXRecordDecl(SD);
 
-    // TODO: consider annotation explicit template instantiation declarations
+    // TODO: consider annotating explicit template instantiation declarations
     // and definitions in the future. They may require unique annotation macros
     // due to differences between visibility and dllexport/dllimport attributes.
     case clang::TSK_ExplicitInstantiationDeclaration:

--- a/Tests/TemplateClasses.hh
+++ b/Tests/TemplateClasses.hh
@@ -4,40 +4,93 @@
 template <typename T, typename U> struct TemplateClassVirtual {
   // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
   virtual void virtualMethod();
+
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  static long staticField;
 };
 
 // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
 template <typename U> struct TemplateClassVirtual<int, U> {
   // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
   virtual void virtualMethod();
+
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  static long staticField;
 };
 
 // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
 extern template class TemplateClassVirtual<long, void*>;
 
 // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
-template class TemplateClassVirtual<unsigned, long>;
+template class TemplateClassVirtual<int, long>;
 
-// CHECK: TemplateClasses.hh:[[@LINE+1]]:20: remark: unexported public interface 'TemplateClassVirtual<int, long>'
-template <> struct TemplateClassVirtual<int, long> {
+// CHECK: TemplateClasses.hh:[[@LINE+1]]:20: remark: unexported public interface 'TemplateClassVirtual<long, int>'
+template <> struct TemplateClassVirtual<long, int> {
   // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
   virtual void virtualMethod();
+
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  static long staticField;
+};
+
+// CHECK: TemplateClasses.hh:[[@LINE+1]]:20: remark: unexported public interface 'TemplateClassVirtual<char, int>'
+template <> struct TemplateClassVirtual<char, int> {
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod();
+
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  static long staticField;
+
+  // CHECK: TemplateClasses.hh:[[@LINE+1]]:10: remark: unexported public interface 'NestedClass'
+  struct NestedClass {
+    // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+    virtual void virtualMethod();
+
+    // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+    static long staticField;
+  };
 };
 
 // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
 template <typename T, typename U> struct TemplateClass {
   // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
   void method();
+
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  static long staticField;
 };
 
 // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
 template <typename U> struct TemplateClass<int, U> {
   // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
   void method();
+
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  static long staticField;
 };
 
 // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
 template <> struct TemplateClass<int, long> {
   // CHECK: TemplateClasses.hh:[[@LINE+1]]:3: remark: unexported public interface 'method'
   void method();
+
+  // CHECK: TemplateClasses.hh:[[@LINE+1]]:{{.*}}: remark: unexported public interface 'staticField'
+  static long staticField;
+};
+
+// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+template <> struct TemplateClass<char, int> {
+  // CHECK: TemplateClasses.hh:[[@LINE+1]]:3: remark: unexported public interface 'method'
+  void method();
+
+  // CHECK: TemplateClasses.hh:[[@LINE+1]]:{{.*}}: remark: unexported public interface 'staticField'
+  static long staticField;
+
+  struct NestedClass {
+    // CHECK: TemplateClasses.hh:[[@LINE+1]]:5: remark: unexported public interface 'method'
+    void method();
+
+    // CHECK: TemplateClasses.hh:[[@LINE+1]]:{{.*}}: remark: unexported public interface 'staticField'
+    static long staticField;
+  };
 };

--- a/Tests/TemplateClasses.hh
+++ b/Tests/TemplateClasses.hh
@@ -1,25 +1,43 @@
 // RUN: %idt --export-macro=IDT_TEST_ABI %s 2>&1 | %FileCheck %s
 
 // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
-template <typename T, typename U> struct TemplateClass {
+template <typename T, typename U> struct TemplateClassVirtual {
   // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
   virtual void virtualMethod();
+};
+
+// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+template <typename U> struct TemplateClassVirtual<int, U> {
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod();
+};
+
+// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+extern template class TemplateClassVirtual<long, void*>;
+
+// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+template class TemplateClassVirtual<unsigned, long>;
+
+// CHECK: TemplateClasses.hh:[[@LINE+1]]:20: remark: unexported public interface 'TemplateClassVirtual<int, long>'
+template <> struct TemplateClassVirtual<int, long> {
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod();
+};
+
+// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+template <typename T, typename U> struct TemplateClass {
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  void method();
 };
 
 // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
 template <typename U> struct TemplateClass<int, U> {
   // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
-  virtual void virtualMethod();
+  void method();
 };
 
 // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
-extern template class TemplateClass<long, void*>;
-
-// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
-template class TemplateClass<unsigned, long>;
-
-// CHECK: TemplateClasses.hh:[[@LINE+1]]:20: remark: unexported public interface 'TemplateClass<int, long>'
 template <> struct TemplateClass<int, long> {
-  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
-  virtual void virtualMethod();
+  // CHECK: TemplateClasses.hh:[[@LINE+1]]:3: remark: unexported public interface 'method'
+  void method();
 };

--- a/Tests/TemplateClasses.hh
+++ b/Tests/TemplateClasses.hh
@@ -1,0 +1,25 @@
+// RUN: %idt --export-macro=IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+template <typename T, typename U> struct TemplateClass {
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod();
+};
+
+// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+template <typename U> struct TemplateClass<int, U> {
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod();
+};
+
+// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+extern template class TemplateClass<long, void*>;
+
+// CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+template class TemplateClass<unsigned, long>;
+
+// CHECK: TemplateClasses.hh:[[@LINE+1]]:20: remark: unexported public interface 'TemplateClass<int, long>'
+template <> struct TemplateClass<int, long> {
+  // CHECK-NOT: TemplateClasses.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod();
+};

--- a/Tests/VTables.hh
+++ b/Tests/VTables.hh
@@ -130,21 +130,3 @@ UnusedAttributeMultiLineDefClass {
   // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
   static unsigned static_field;
 };
-
-// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
-template <typename T, typename U> struct TemplateClass {
-  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
-  virtual void virtualMethod();
-};
-
-// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
-template <typename U> struct TemplateClass<int, U> {
-  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
-  virtual void virtualMethod();
-};
-
-// CHECK: VTables.hh:[[@LINE+1]]:20: remark: unexported public interface 'TemplateClass<int, long>'
-template <> struct TemplateClass<int, long> {
-  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
-  virtual void virtualMethod();
-};

--- a/Tests/VTables.hh
+++ b/Tests/VTables.hh
@@ -130,3 +130,21 @@ UnusedAttributeMultiLineDefClass {
   // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
   static unsigned static_field;
 };
+
+// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+template <typename T, typename U> struct TemplateClass {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod();
+};
+
+// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+template <typename U> struct TemplateClass<int, U> {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod();
+};
+
+// CHECK: VTables.hh:[[@LINE+1]]:20: remark: unexported public interface 'TemplateClass<int, long>'
+template <> struct TemplateClass<int, long> {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod();
+};


### PR DESCRIPTION
## Purpose
Fix class-level export annotation handling for template class declarations.

## Overview
This patch makes the following behavioral changes to IDS:
1. Do not add class-level annotations to template class declarations.
2. Ensure class-level annotations are added to fully specialized template class declarations.

## Validation
1. New test cases to verify only fully-specialized template class declarations with virtual methods are annotated for export.
2. Ran tests locally on Windows and Linux,