### PR TITLE
skip annotating classes with only defaulted, deleted, or pure virtual methods

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -254,8 +254,8 @@ public:
     bool should_export_record = false;
     for (const auto *MD : RD->methods())
       if ((should_export_record =
-               (MD->isVirtual() && !MD->isPureVirtual() && !MD->hasBody() &&
-                !MD->isDefaulted() && !MD->isDeleted())))
+               !(MD->isPureVirtual() || MD->isDefaulted() || MD->isDeleted()) &&
+               (MD->isVirtual() && !MD->hasBody());
         break;
 
     const bool is_exported_record = is_symbol_exported(RD);

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -255,7 +255,7 @@ public:
     for (const auto *MD : RD->methods())
       if ((should_export_record =
                !(MD->isPureVirtual() || MD->isDefaulted() || MD->isDeleted()) &&
-               (MD->isVirtual() && !MD->hasBody());
+               (MD->isVirtual() && !MD->hasBody())))
         break;
 
     const bool is_exported_record = is_symbol_exported(RD);

--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -253,7 +253,9 @@ public:
     // access level.
     bool should_export_record = false;
     for (const auto *MD : RD->methods())
-      if ((should_export_record = (MD->isVirtual() && !MD->hasBody())))
+      if ((should_export_record =
+               (MD->isVirtual() && !MD->isPureVirtual() && !MD->hasBody() &&
+                !MD->isDefaulted() && !MD->isDeleted())))
         break;
 
     const bool is_exported_record = is_symbol_exported(RD);

--- a/Tests/VTables.hh
+++ b/Tests/VTables.hh
@@ -10,13 +10,54 @@ struct ClassWithInlineVirtualMethod {
   static unsigned static_field;
 };
 
+// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+struct ClassWithDefaultVirtualDestructor {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual ~ClassWithDefaultVirtualDestructor() = default;
+};
+
+// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+struct ClassWithDeletedVirtualDestructor {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual ~ClassWithDeletedVirtualDestructor() = delete;
+};
+
+// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+struct ClassWithPureVirtualMethod {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod() = 0;
+};
+
 // CHECK: VTables.hh:[[@LINE+1]]:8: remark: unexported public interface 'ClassWithExternVirtualMethod'
 struct ClassWithExternVirtualMethod {
-private:
   // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
-  virtual void virtualMedhod();
+  virtual void virtualMethod();
   // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
   void method();
+};
+
+// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+struct DerivedClassWithInlineOverriddenExternVirtualMethod : public ClassWithExternVirtualMethod {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  void virtualMethod() override {}
+};
+
+// CHECK: VTables.hh:[[@LINE+1]]:8: remark: unexported public interface 'DerivedClassWithExternOverriddenExternVirtualMethod'
+struct DerivedClassWithExternOverriddenExternVirtualMethod : public ClassWithExternVirtualMethod {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  void virtualMethod() override;
+};
+
+// CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+struct DerivedClassWithInlineOverriddenPureVirtualMethod : public ClassWithPureVirtualMethod {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  void virtualMethod() override {}
+};
+
+// CHECK: VTables.hh:[[@LINE+1]]:8: remark: unexported public interface 'DerivedClassWithExternOverriddenPureVirtualMethod'
+struct DerivedClassWithExternOverriddenPureVirtualMethod : public ClassWithPureVirtualMethod {
+  // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}
+  void virtualMethod() override;
 };
 
 // CHECK-NOT: VTables.hh:[[@LINE+1]]:{{.*}}


### PR DESCRIPTION
## Purpose
Make annotating at the class level for vtable export more strict.

## Background 
b7cb8df871f958ac05e9ad11942a2761712e05d6 introduced exporting at the class level for class definitions with out-of-line virtual methods. However, the check for virtual methods requiring export was not as strict as it could be: defaulted, deleted, and pure virtual methods do not require the vtable to be exported.

## Validation
1. New test cases to verify stricter virtual method checks.
2. Ran tests locally on Windows and Linux,
