### PR TITLE
test cases for methods defined in the header

### DIFF
--- a/Tests/OutOfLineInlineMethods.hh
+++ b/Tests/OutOfLineInlineMethods.hh
@@ -1,0 +1,40 @@
+// RUN: %idt --export-macro=IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+// CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+struct ClassWithOutOfLineMethods {
+  // CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+  ClassWithOutOfLineMethods();
+
+  // CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+  ~ClassWithOutOfLineMethods();
+
+  // CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+  void method();
+
+  // CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+  inline void inlineMethod();
+};
+
+// CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+inline ClassWithOutOfLineMethods::ClassWithOutOfLineMethods() {}
+
+// CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+inline ClassWithOutOfLineMethods::~ClassWithOutOfLineMethods() {}
+
+// CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+void ClassWithOutOfLineMethods::method() {}
+
+// CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+inline void ClassWithOutOfLineMethods::inlineMethod() {}
+
+// CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+void method();
+
+// CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+void method() {};
+
+// CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+inline void inlineMethod();
+
+// CHECK-NOT: OutOfLineInlineMethods.hh:[[@LINE+1]]:{{.*}}
+inline void inlineMethod() {};


### PR DESCRIPTION
Add test cases to ensure that method and function declarations that are defined later in the header are not annotated. I encountered this case while annotating LLVM and wanted to confirm the behavior with tests.