### PR TITLE
annotate overloaded private class members where needed

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -514,6 +514,19 @@ public:
     return true;
   }
 
+  // Visit every unresolved member expression in the compilation unit to
+  // determine if there are overloaded private methods that might be called. In
+  // this uncommon case, the private method should be annotated.
+  bool VisitUnresolvedMemberExpr(clang::UnresolvedMemberExpr *E) {
+    // Iterate over potential declarations
+    for (const clang::NamedDecl *ND : E->decls())
+      if (const auto *MD = llvm::dyn_cast<clang::CXXMethodDecl>(ND))
+        if (MD->getAccess() == clang::AccessSpecifier::AS_private)
+          export_function_if_needed(MD);
+
+    return true;
+  }
+
   // Visit every constructor call in the compilation unit to determine if there
   // are any inline calls to private constructors. In this uncommon case, the
   // private constructor must be annotated for export. Constructor calls are not

--- a/Tests/TemplateCallsPrivateMethod.hh
+++ b/Tests/TemplateCallsPrivateMethod.hh
@@ -1,4 +1,4 @@
-// RUN: %idt --export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+// RUN: %idt --extra-arg="-fno-delayed-template-parsing" --export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
 
 class TemplateCallsPrivateMethod {
 public:

--- a/Tests/TemplateCallsPrivateMethod.hh
+++ b/Tests/TemplateCallsPrivateMethod.hh
@@ -1,0 +1,20 @@
+// RUN: %idt --export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+class TemplateCallsPrivateMethod {
+public:
+  // CHECK-NOT: TemplateCallsPrvateMethod.hh:[[@LINE+1]]:{{.*}}
+  template <typename T> void publicTemplateMethod(T x) {
+    privateMethodForTemplate(x);
+  }
+
+private:
+  // NOTE: we use CHECK-DAG here because these remarks may come out of order and
+  // we cannot control the order by rearranging members.
+
+  // CHECK-DAG: TemplateCallsPrivateMethod.hh:[[@LINE+1]]:3: remark: unexported public interface 'privateMethodForTemplate'
+  void privateMethodForTemplate(long x) const;
+
+  // CHECK-DAG: TemplateCallsPrivateMethod.hh:[[@LINE+1]]:3: remark: unexported public interface 'privateMethodForTemplate'
+  void privateMethodForTemplate(int x) const;
+};
+


### PR DESCRIPTION
## Purpose
Running IDs across the LLVM source, I observed a few cases where private methods that should have been annotated due to being referenced in the same translation unit. In these instances, the missed private methods had overloads and their references were ambiguous. This PR addresses the issue and makes IDS properly flag these methods for export.

## Overview
1. Override `VisitUnresolvedMemberExpr` which gets called in this scenario. Invoke the existing `export_function_if_needed` for each method declaration the expression may reference. This is only done for private methods because public methods will always be annotated.
2. Add a new test case. For this test force Clang language options to `-fno-delayed-template-parsing`, which is already the default on Linux and Darwin. This is required on Windows, where the default behavior is `-fdelayed-template-parsing` to better match MSVC behavior. More details [here](https://clang.llvm.org/docs/MSVCCompatibility.html). Without this argument, the new test case does not pass when run on Windows.

## Validation
1. New tests case.
2. Ran tests on Windows and Linux.
3. Manually ran on a subset of the llvm headers and inspected results.