### PR TITLE
export classes with pure virtual destructors

### DIFF
--- a/Tests/PureVirtualDestructor.hh
+++ b/Tests/PureVirtualDestructor.hh
@@ -1,0 +1,47 @@
+// RUN: %idt --export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+// PureVirtualClass should get annotated because it contains a pure virtual
+// destructor with an out-of-line definition.
+
+// CHECK: PureVirtualDestructor.hh:[[@LINE+1]]:8: remark: unexported public interface 'PureVirtualClass'
+struct PureVirtualClass {
+// CHECK-NOT: PureVirtualDestructor.hh:[[@LINE-1]]:{{.*}}
+
+  // CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+  virtual ~PureVirtualClass() = 0;
+  // CHECK-NOT: PureVirtualDestructor.hh:[[@LINE-1]]:{{.*}}
+
+  // CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod() = 0;
+};
+
+// AnotherPureVirtualClass should get NOT get annotated because its pure virtual
+// destructor has an out-of-line definition within this translation unit.
+
+// CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+struct AnotherPureVirtualClass {
+  // CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+  virtual ~AnotherPureVirtualClass() = 0;
+
+  // CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod() = 0;
+};
+
+// CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+AnotherPureVirtualClass::~AnotherPureVirtualClass() {}
+
+// YetAnotherPureVirtualClass should get NOT get annotated because its pure
+// virtual destructor has an out-of-line defaulted definition within this
+// translation unit.
+
+// CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+struct YetAnotherPureVirtualClass {
+  // CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+  virtual ~YetAnotherPureVirtualClass() = 0;
+
+  // CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+  virtual void virtualMethod() = 0;
+};
+
+// CHECK-NOT: PureVirtualDestructor.hh:[[@LINE+1]]:{{.*}}
+YetAnotherPureVirtualClass::~YetAnotherPureVirtualClass() = default;


### PR DESCRIPTION
## Purpose
IDS should annotate classes that have pure virtual destructors with out-of-line implementations. I have observed a small number of these cases while annotating the LLVM codebase and found it was easy to identify and fix automatically with IDS.

## Validation
1. New test cases.
2. Ran all tests on Linux and Windows.
3. Manually ran on LLVM source and verified it found and fixed 3 instances.