### PR TITLE
properly position annotation on qualified record declarations

### DIFF
--- a/Sources/idt/idt.cc
+++ b/Sources/idt/idt.cc
@@ -436,7 +436,9 @@ class visitor : public clang::RecursiveASTVisitor<visitor> {
     // Insert the annotation immediately before the tag name, which is the
     // position returned by getLocation.
     clang::LangOptions LO = RD->getASTContext().getLangOpts();
-    clang::SourceLocation SLoc = RD->getLocation();
+    clang::SourceLocation SLoc = RD->getQualifier()
+                                     ? RD->getQualifierLoc().getBeginLoc()
+                                     : RD->getLocation();
     const clang::SourceLocation location =
         context_.getFullLoc(SLoc).getExpansionLoc();
     unexported_public_interface(RD, location)

--- a/Tests/QualifiedRecordNames.hh
+++ b/Tests/QualifiedRecordNames.hh
@@ -1,0 +1,29 @@
+// RUN: %idt --export-macro=IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+namespace ContainerNamespace {
+  // CHECK-NOT: QualifiedRecordNames.hh:[[@LINE+1]]:{{.*}}
+  struct QualifiedNameClass;
+}
+
+// CHECK: QualifiedRecordNames.hh:[[@LINE+1]]:8: remark: unexported public interface 'QualifiedNameClass'
+struct ContainerNamespace::QualifiedNameClass {
+// CHECK-NOT: QualifiedRecordNames.hh:[[@LINE-1]]:{{.*}}
+
+  // CHECK-NOT: QualifiedRecordNames.hh:[[@LINE+1]]:{{.*}}
+  virtual void method();
+};
+
+// CHECK-NOT: QualifiedRecordNames.hh:[[@LINE+1]]:{{.*}}
+struct ContainerClass {
+  // CHECK-NOT: QualifiedRecordNames.hh:[[@LINE+1]]:{{.*}}
+  struct QualifiedNameClass;
+};
+
+// CHECK: QualifiedRecordNames.hh:[[@LINE+1]]:8: remark: unexported public interface 'QualifiedNameClass'
+struct ContainerClass::QualifiedNameClass {
+// CHECK-NOT: QualifiedRecordNames.hh:[[@LINE-1]]:{{.*}}
+
+  // CHECK-NOT: QualifiedRecordNames.hh:[[@LINE+1]]:{{.*}}
+  virtual void method();
+};
+


### PR DESCRIPTION
## Overview
Properly position the annotation on qualified struct/class declarations.

## Background
Prior to this change, IDS would incorrectly emit the position for a record annotation like so:
```
/home/andrew/src/ids/Tests/QualifiedRecordNames.hh:9:28: remark: unexported public interface 'QualifiedNameClass'
    9 | struct ContainerNamespace::QualifiedNameClass {
      |                            ^
      |                            IDT_TEST_ABI
```
Having the annotation in this position is invalid and will not compile.

NOTE: special handling for qualified names is only necessary when annotating records. This is because the annotation has to follow the `class`/`struct`/`union` keyword. For variables and functions, the annotation always goes at the beginning of the declaration reported by `getBeginLoc()`.

## Validation
New test cases.
Manually verified the fixit is properly positioned.
```
/home/andrew/src/ids/Tests/QualifiedRecordNames.hh:9:8: remark: unexported public interface 'QualifiedNameClass'
    9 | struct ContainerNamespace::QualifiedNameClass {
      |        ^
      |        IDT_TEST_ABI
```