### PR TITLE
optionally export private static fields of classes with friends

### DIFF
--- a/Tests/FriendReadsPrivateStaticField.hh
+++ b/Tests/FriendReadsPrivateStaticField.hh
@@ -1,0 +1,14 @@
+// RUN: %idt --friendly-fields --export-macro IDT_TEST_ABI %s 2>&1 | %FileCheck %s
+
+struct KeyType {};
+
+template <typename T> struct FriendTemplate {
+  static KeyType *getKey() { return &T::Key; }
+};
+
+class ClassWithPrivateStaticField : public FriendTemplate<ClassWithPrivateStaticField> {
+  friend FriendTemplate<ClassWithPrivateStaticField>;
+
+  // CHECK: FriendReadsPrivateStaticField.hh:[[@LINE+1]]:3: remark: unexported public interface 'Key'
+  static KeyType Key;
+};


### PR DESCRIPTION
## Purpose
Add a new command line option to IDS which enables it to export static, private fields of classes that have friend declarations. This fix specifically addresses feedback on llvm/llvm-project#136623 by automatically annotating `AnalysisKey` fields.

## Overview
Adds a new `--friendly-fields` command line argument to IDS to enable exporting private fields for friend access. When this new mode is enabled, private fields are exported by `VisitVarDecl` if the containing class has at least one friend declaration.

### NOTES:
* I made this functionality a command line option because it doesn't seem like appropriate default behavior.
* I did not add functionality to export private methods in the same conditions. Unlike just exporting private static fields, exporting methods over-exports a significant number of private methods when running against LLVM. It could easily be added as another command line option, but we don't currently have a use for it.

## Validation
Added a new test case.
Ran tests on Windows, Fedora, and MacOS.